### PR TITLE
fix(reports): decouple domain models and support string UUIDs

### DIFF
--- a/pharmagob/mongodb_repositories/reports.py
+++ b/pharmagob/mongodb_repositories/reports.py
@@ -1,42 +1,27 @@
 from typing import Optional
-from bson import ObjectId
 from time import time
-from pharmagob.v1.models.reports import ReportRequestModel
-from pharmagob.v1.repository_interfaces.reports import ReportRepositoryInterface
+
 from .base import BaseMongoDbRepository
 
-class ReportRepository(BaseMongoDbRepository, ReportRepositoryInterface):
-    def get_by_id(self, report_id: str) -> Optional[ReportRequestModel]:
-        if not ObjectId.is_valid(report_id):
-            return None
-            
-        data = self._collection.find_one({"_id": ObjectId(report_id)})
+
+class ReportRepository(BaseMongoDbRepository):
+    def get_by_id(self, report_id: str) -> Optional[dict]:
+        data = self._collection.find_one({"_id": report_id})
+
         if not data:
             return None
-            
-        return ReportRequestModel(**data)
 
-    def create(self, report: ReportRequestModel) -> ReportRequestModel:
-        report_data = report.dict()
-        
-        if isinstance(report_data.get("_id"), str):
-            report_data["_id"] = ObjectId(report_data["_id"])
-            
-        self._collection.insert_one(report_data)
-        return report
+        return data
 
     def update_status(self, report_id: str, status: str, progress: int) -> bool:
-        if not ObjectId.is_valid(report_id):
-            return False
-            
         result = self._collection.update_one(
-            {"_id": ObjectId(report_id)},
+            {"_id": report_id},
             {
                 "$set": {
                     "status": status,
                     "progress": progress,
-                    "updated_at": round(time() * 1000)
+                    "updated_at": round(time() * 1000),
                 }
-            }
+            },
         )
         return result.modified_count > 0


### PR DESCRIPTION
- Removed `ReportRequestModel` dependency from the repository layer to return raw dictionaries, respecting separation of concerns.
- Removed the custom `create` method to properly inherit and use the typed `create` method from `BaseMongoDbRepository`.
- Removed `ObjectId` validation and casting to fully support standard string UUIDs as document primary keys.